### PR TITLE
Fix method typo in integration test

### DIFF
--- a/ApiTemplate.Presentation.Web.Tests.Integration/Account/AccountTests.cs
+++ b/ApiTemplate.Presentation.Web.Tests.Integration/Account/AccountTests.cs
@@ -91,7 +91,7 @@ namespace ApiTemplate.Presentation.Web.Tests.Integration.Account
         }
 
         [Fact]
-        public async Task Should_Confrim_User_Email_Successfully()
+        public async Task Should_Confirm_User_Email_Successfully()
         {
             // Act
             var (createAccount, sendDigitCode, confirmUserEmail, isEmailConfirmed) = await CreateAndConfirmAccount(CreateAccountModel());


### PR DESCRIPTION
## Summary
- fix typo in `Should_Confirm_User_Email_Successfully`
- run test suite (fails: Docker not available)

## Testing
- `dotnet test ApiTemplate.sln --verbosity minimal` *(fails: Docker not running)*

------
https://chatgpt.com/codex/tasks/task_e_68470bf4ff04832faa9b2e5f85408444