### PR TITLE
Fix ExecuteHelper batching logic and add tests

### DIFF
--- a/ApiTemplate.SharedKernel.Tests/ExecuteHelperTests.cs
+++ b/ApiTemplate.SharedKernel.Tests/ExecuteHelperTests.cs
@@ -1,0 +1,36 @@
+using ApiTemplate.SharedKernel.Extensions;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ApiTemplate.SharedKernel.Tests
+{
+    public class ExecuteHelperTests
+    {
+        [Fact]
+        public async Task ExecuteWhileAsync_ProcessesFinalSingleItemBatch()
+        {
+            // Arrange
+            var source = new List<int> { 1, 2, 3, 4, 5 };
+            var processed = new List<int>();
+
+            async Task<List<int>> GetItems(int skip, int take)
+            {
+                return await Task.FromResult(source.Skip(skip).Take(take).ToList());
+            }
+
+            async Task DoAsync(List<int> items)
+            {
+                processed.AddRange(items);
+                await Task.CompletedTask;
+            }
+
+            // Act
+            var executed = await ExecuteHelper<int>.ExecuteWhileAsync(GetItems, DoAsync, 2);
+
+            // Assert
+            Assert.True(executed);
+            Assert.Equal(source, processed);
+        }
+    }
+}

--- a/ApiTemplate.SharedKernel/Extensions/ExecuteHelper.cs
+++ b/ApiTemplate.SharedKernel/Extensions/ExecuteHelper.cs
@@ -12,14 +12,14 @@ namespace ApiTemplate.SharedKernel.Extensions
             int cntToSkip = 0;
             bool execAtLeastOnce = false;
             var items = await getCnt(cntToSkip, cntToTake);
-            if (items.Count > 0)
-                do
-                {
-                    await @do(items);
-                    cntToSkip++;
-                    execAtLeastOnce = true;
-                    items = await getCnt(cntToSkip, cntToTake);
-                } while (items.Count > 1);
+
+            while (items.Count > 0)
+            {
+                await @do(items);
+                cntToSkip += cntToTake;
+                execAtLeastOnce = true;
+                items = await getCnt(cntToSkip, cntToTake);
+            }
 
             return execAtLeastOnce;
         }


### PR DESCRIPTION
## Summary
- fix batching logic in `ExecuteHelper.ExecuteWhileAsync`
- add unit test for final single-item batch
- run all tests

## Testing
- `dotnet test ApiTemplate.SharedKernel.Tests/ApiTemplate.SharedKernel.Tests.csproj --no-build -v minimal`
- `dotnet test ApiTemplate.Domain.Tests/ApiTemplate.Domain.Tests.csproj -v minimal`
- `dotnet test ApiTemplate.Application.Tests/ApiTemplate.Application.Tests.csproj -v minimal`
- `dotnet test ApiTemplate.Infrastructure.Tests/ApiTemplate.Infrastructure.Tests.csproj -v minimal`
- `dotnet test ApiTemplate.sln --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68470bf3c7e4832fa7b35ea97712400c